### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/ACAviation/ac-aviation.github.io.png?label=ready&title=Ready)](https://waffle.io/ACAviation/ac-aviation.github.io)
 *Please refer to this repository [ac-aviation.github.io wiki](https://github.com/ACAviation/ac-aviation.github.io/wiki) for assistance.*
 
 # CAAT AOC-R Task List by Chapter


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/ACAviation/ac-aviation.github.io

This was requested by a real person (user paisan) on waffle.io, we're not trying to spam you.